### PR TITLE
load-docker-images.yml: few enhancements

### DIFF
--- a/load-docker-images.yml
+++ b/load-docker-images.yml
@@ -1,74 +1,66 @@
 ---
 - hosts: localhost
+  become: true
   tasks:
     - name: Create directory for local repository
-      shell: "sudo mkdir -p /var/lib/registry"
+      shell: "mkdir -p /var/lib/registry"
     - name: Tell Docker to setup local registry
-      shell: "sudo docker run -d -p 5000:5000 --restart=always --name registry -v /var/lib/registry:/var/lib/registry registry:2"
+      docker_container:
+        name: registry
+        restart_policy: always
+        ports:
+         - 5000:5000
+        volumes:
+         - /var/lib/registry:/var/lib/registry registry:2
     - name: Restart docker after setting up local registry
-      shell: "sudo service docker restart" 
+      service:
+        name: docker
+        action: restarted
     - name: admin-portal
       docker_image:
         name: smarthome2cloud/admin-portal
-      become: True
     - name: Tag and push to local registry
       docker_image:
         name: smarthome2cloud/admin-portal
         repository: 192.168.2.117:5000/admin-portal
         push: yes
-      become: True
-
     - name: celery-worker
       docker_image:
         name: smarthome2cloud/celery-worker
-      become: True
     - name: Tag and push to local registry
       docker_image:
         name: smarthome2cloud/celery-worker
         repository: 192.168.2.117:5000/celery-worker
         push: yes
-      become: True
-
     - name: home-portal
       docker_image:
         name: smarthome2cloud/home-portal
-      become: True
     - name: Tag and push to local registry
       docker_image:
         name: smarthome2cloud/home-portal
         repository: 192.168.2.117:5000/home-portal
         push: yes
-      become: True
-
     - name: mariadb-master
       docker_image:
         name: smarthome2cloud/mariadb-master
-      become: True
     - name: Tag and push to local registry
       docker_image:
         name: smarthome2cloud/mariadb-master
         repository: 192.168.2.117:5000/mariadb-master
         push: yes
-      become: True
-
     - name: rabbitmq
       docker_image:
         name: smarthome2cloud/rabbitmq
-      become: True
     - name: Tag and push to local registry
       docker_image:
         name: smarthome2cloud/rabbitmq
         repository: 192.168.2.117:5000/rabbitmq
         push: yes
-      become: True
-
     - name: smarthome-gateway
       docker_image:
         name: smarthome2cloud/smarthome-gateway
-      become: True
     - name: Tag and push to local registry
       docker_image:
         name: smarthome2cloud/smarthome-gateway
         repository: 192.168.2.117:5000/smarthome-gateway
         push: yes
-      become: True


### PR DESCRIPTION
* Use 'become: true' at the play level instead of tasks given that
  all tasks in the playbook require elevated privileges
* Use Ansible 'service' task to restart the 'docker' service
* Use Ansible 'docker_container' to start the local Docker registry

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>